### PR TITLE
Crash in login activity without connection

### DIFF
--- a/app/src/main/java/com/perflyst/twire/activities/setup/LoginActivity.java
+++ b/app/src/main/java/com/perflyst/twire/activities/setup/LoginActivity.java
@@ -331,8 +331,8 @@ public class LoginActivity extends UsageTrackingAppCompatActivity {
     }
 
     private void initSnackbar() {
-        new SnackBar(this)
-                .applyStyle(R.style.snack_bar_style_mobile);
+        mSnackbar = new SnackBar(this);
+        mSnackbar.applyStyle(R.style.snack_bar_style_mobile);
     }
 
     private void initLoginView() {


### PR DESCRIPTION
Error at LoginActivity which crashed the application when trying to open LoginActivity whitout internet conection, this happened because the method initSnackbar didn't initialized the snackbar which caused a NullPointerException. Now, it is initializated properly.