### PR TITLE
Don't encode stream tokens twice and encode VOD tokens

### DIFF
--- a/app/src/main/java/com/perflyst/twire/tasks/GetLiveStreamURL.java
+++ b/app/src/main/java/com/perflyst/twire/tasks/GetLiveStreamURL.java
@@ -80,7 +80,7 @@ public class GetLiveStreamURL extends AsyncTask<String, Void, HashMap<String, St
         String resultString = Service.urlToJSONString("https://api.twitch.tv/api/channels/" + streamerName + "/access_token");
         try {
             JSONObject resultJSON = new JSONObject(resultString);
-            tokenString = URLEncoder.encode(resultJSON.getString("token")); // URL Encode token
+            tokenString = resultJSON.getString("token");
             sig = resultJSON.getString("sig");
 
             Log.d("ACCESS_TOKEN_STRING", tokenString);
@@ -180,7 +180,7 @@ public class GetLiveStreamURL extends AsyncTask<String, Void, HashMap<String, St
         return resultList;
     }
 
-    private String safeEncode(String s) {
+    protected String safeEncode(String s) {
         try {
             return URLEncoder.encode(s, "utf-8");
         } catch (UnsupportedEncodingException ignore) {

--- a/app/src/main/java/com/perflyst/twire/tasks/GetVODStreamURL.java
+++ b/app/src/main/java/com/perflyst/twire/tasks/GetVODStreamURL.java
@@ -29,13 +29,13 @@ public class GetVODStreamURL extends GetLiveStreamURL {
             String url = "https://api.twitch.tv/api/vods/" + vodId + "/access_token";
             Log.d(LOG_TAG, url);
             JSONObject topobject = new JSONObject(Service.urlToJSONString(url));
-            token = topobject.getString("token").replaceAll("\\\\", ""); // Remove all backslashes from the returned string. We need the string to make a jsonobject
+            token = topobject.getString("token");
             sig = topobject.getString("sig");
         } catch (JSONException e) {
             e.printStackTrace();
         }
 
-        String vodURL = String.format("http://usher.twitch.tv/vod/%s?nauthsig=%s&nauth=%s", vodId, sig, token);
+        String vodURL = String.format("http://usher.twitch.tv/vod/%s?nauthsig=%s&nauth=%s", vodId, sig, safeEncode(token));
         Log.d(LOG_TAG, "HSL Playlist URL: " + vodURL);
         return parseM3U8(vodURL);
     }


### PR DESCRIPTION
@Perflyst ported over some URL encoding for the stream stream tokens which was already being done later in the code.
I also made it encode the VOD tokens for consistency, I don't know if it fixes any bugs.

Closes #63