### PR TITLE
Disable tips as soon as navigation drawer is opened the first time

### DIFF
--- a/app/src/main/java/com/perflyst/twire/fragments/NavigationDrawerFragment.java
+++ b/app/src/main/java/com/perflyst/twire/fragments/NavigationDrawerFragment.java
@@ -138,6 +138,12 @@ public class NavigationDrawerFragment extends Fragment {
                     return;
                 }
                 super.onDrawerOpened(drawerView);
+
+                if (!mSettings.isTipsShown()) {
+                    // Disable tips as soon as drawer is opened the first time
+                    mSettings.setTipsShown(true);
+                }
+
                 mAppIcon.startAnimation(AnimationUtils.loadAnimation(getActivity(), R.anim.anim_icon_rotation));
             }
 


### PR DESCRIPTION
Due to the recent edits made for #8 the tip "Click to Navigate" won't be disabled anymore and will show up every time one switches the view in the navigation drawer. This only happens if tips hadn't been disabled yet (fresh install).
This fixes the issue.