### PR TITLE
Get Twire working on Android 4.x

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
         debug {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,4 +86,7 @@ dependencies {
     implementation 'com.google.android.exoplayer:exoplayer-hls:2.11.4'
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.11.4'
     implementation 'com.google.android.exoplayer:extension-mediasession:2.11.4'
+
+    // https://github.com/google/conscrypt/releases
+    implementation 'org.conscrypt:conscrypt-android:2.4.0'
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,1 +1,2 @@
 -keep public class * extends com.bumptech.glide.module.AppGlideModule
+-dontobfuscate

--- a/app/src/main/java/com/perflyst/twire/TwireApplication.java
+++ b/app/src/main/java/com/perflyst/twire/TwireApplication.java
@@ -11,6 +11,10 @@ import androidx.multidex.MultiDexApplication;
 
 import com.perflyst.twire.utils.TLSSocketFactoryCompat;
 
+import java.security.Security;
+
+import org.conscrypt.Conscrypt;
+
 /**
  * Created by SebastianRask on 20-02-2016.
  */
@@ -24,12 +28,13 @@ public class TwireApplication extends MultiDexApplication {
         super.onCreate();
         mContext = this.getApplicationContext();
 
+        // Twitch API requires TLS 1.2, which may be unavailable/not enabled on Android 4.1 - 4.4.
+        // Install modern TLS protocols using a security provider, and enable them by default in a
+        // custom SSLSocketFactory.
+        Security.insertProviderAt(Conscrypt.newProvider(), 1);
+        TLSSocketFactoryCompat.setAsDefault();
+
         initNotificationChannels();
-        // Twitch requires TLS 1.2, which may be available on Android 4.1 - 4.4, but will not be
-        // enabled by default. Try to enable it, if it is available.
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-            TLSSocketFactoryCompat.setAsDefault();
-        }
     }
 
     @Override

--- a/app/src/main/java/com/perflyst/twire/TwireApplication.java
+++ b/app/src/main/java/com/perflyst/twire/TwireApplication.java
@@ -9,6 +9,8 @@ import android.os.Build;
 import androidx.multidex.MultiDex;
 import androidx.multidex.MultiDexApplication;
 
+import com.perflyst.twire.utils.TLSSocketFactoryCompat;
+
 /**
  * Created by SebastianRask on 20-02-2016.
  */
@@ -23,6 +25,11 @@ public class TwireApplication extends MultiDexApplication {
         mContext = this.getApplicationContext();
 
         initNotificationChannels();
+        // Twitch requires TLS 1.2, which may be available on Android 4.1 - 4.4, but will not be
+        // enabled by default. Try to enable it, if it is available.
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+            TLSSocketFactoryCompat.setAsDefault();
+        }
     }
 
     @Override

--- a/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
+++ b/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
@@ -2,6 +2,7 @@ package com.perflyst.twire.fragments;
 
 import android.app.Activity;
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -53,6 +54,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.transition.Fade;
 import androidx.transition.TransitionManager;
+import androidx.media.session.MediaButtonReceiver;
 
 import com.afollestad.materialdialogs.DialogAction;
 import com.balysv.materialripple.MaterialRippleLayout;
@@ -514,7 +516,13 @@ public class StreamFragment extends Fragment implements Player.EventListener, Pl
             if (currentMediaSource != null)
                 player.prepare(currentMediaSource);
 
-            mediaSession = new MediaSessionCompat(getContext(), getContext().getPackageName());
+            ComponentName mediaButtonReceiver = new ComponentName(
+                    getContext(), MediaButtonReceiver.class);
+            mediaSession = new MediaSessionCompat(
+                    getContext(),
+                    getContext().getPackageName(),
+                    mediaButtonReceiver,
+                    null);
             MediaSessionConnector mediaSessionConnector = new MediaSessionConnector(mediaSession);
             mediaSessionConnector.setPlayer(player);
             mediaSession.setActive(true);

--- a/app/src/main/java/com/perflyst/twire/utils/TLSSocketFactoryCompat.java
+++ b/app/src/main/java/com/perflyst/twire/utils/TLSSocketFactoryCompat.java
@@ -106,7 +106,7 @@ public class TLSSocketFactoryCompat extends SSLSocketFactory {
 
     private Socket enableTLSOnSocket(final Socket socket) {
         if (socket instanceof SSLSocket) {
-            ((SSLSocket) socket).setEnabledProtocols(new String[]{"TLSv1.2"});
+            ((SSLSocket) socket).setEnabledProtocols(new String[]{"TLSv1.2", "TLSv1.3"});
         }
         return socket;
     }

--- a/app/src/main/java/com/perflyst/twire/utils/TLSSocketFactoryCompat.java
+++ b/app/src/main/java/com/perflyst/twire/utils/TLSSocketFactoryCompat.java
@@ -1,0 +1,113 @@
+package com.perflyst.twire.utils;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+
+
+/**
+ * This is an extension of the SSLSocketFactory which enables TLS 1.2 and 1.1.
+ * Created for usage on Android 4.1-4.4 devices, which haven't enabled those by default.
+ *
+ * Copied from https://github.com/TeamNewPipe/NewPipe-legacy/blob/master/app/src/main/java
+ * /org/schabi/newpipelegacy/util/TLSSocketFactoryCompat.java
+ */
+public class TLSSocketFactoryCompat extends SSLSocketFactory {
+
+
+    private static TLSSocketFactoryCompat instance = null;
+
+    private SSLSocketFactory internalSSLSocketFactory;
+
+    public TLSSocketFactoryCompat() throws KeyManagementException, NoSuchAlgorithmException {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, null, null);
+        internalSSLSocketFactory = context.getSocketFactory();
+    }
+
+
+    public TLSSocketFactoryCompat(final TrustManager[] tm)
+            throws KeyManagementException, NoSuchAlgorithmException {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, tm, new java.security.SecureRandom());
+        internalSSLSocketFactory = context.getSocketFactory();
+    }
+
+    public static TLSSocketFactoryCompat getInstance()
+            throws NoSuchAlgorithmException, KeyManagementException {
+        if (instance != null) {
+            return instance;
+        }
+        instance = new TLSSocketFactoryCompat();
+        return instance;
+    }
+
+    public static void setAsDefault() {
+        try {
+            HttpsURLConnection.setDefaultSSLSocketFactory(getInstance());
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return internalSSLSocketFactory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return internalSSLSocketFactory.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket());
+    }
+
+    @Override
+    public Socket createSocket(final Socket s, final String host, final int port,
+                               final boolean autoClose) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(final String host, final int port) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(final String host, final int port, final InetAddress localHost,
+                               final int localPort) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(
+                host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(final InetAddress host, final int port) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(final InetAddress address, final int port,
+                               final InetAddress localAddress, final int localPort)
+            throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(
+                address, port, localAddress, localPort));
+    }
+
+    private Socket enableTLSOnSocket(final Socket socket) {
+        if (socket instanceof SSLSocket) {
+            ((SSLSocket) socket).setEnabledProtocols(new String[]{"TLSv1.2"});
+        }
+        return socket;
+    }
+}


### PR DESCRIPTION
- The Twitch API requires TLS 1.2, but Android 4.1 - 4.4 devices may not have the TLS 1.2 protocol, or they have it, but it is not enabled by default. Install the [Conscrypt](https://github.com/google/conscrypt) security provider to make modern TLS 1.2 and 1.3 protocols available to all devices, and use a custom `SSLSocketFactory` to enable them.
  - Conscrypt will introduce ~4 MB to the APK size, so enable minification to reduce this a bit. Obfuscation has not been enabled for now, but will make the APK even smaller. There are three places in `app/src/main/java/com/perflyst/twire/service/Service.java` where reflection is used, so those would have to have ProGuard rules included to keep those parts working. I did try this out and encountered no errors that didn't already occur without minification, but decided full minification could be left for a separate PR.
- Fix an issue with how `MediaSessionCompat` should be instantiated on devices < Android 5.
  - From https://developer.android.com/reference/kotlin/android/support/v4/media/session/MediaSessionCompat
    > This method will only work on android.os.Build.VERSION_CODES#LOLLIPOP and later. Earlier platform versions must include the media button receiver in the constructor.

### Known issues
- Thumbnails fail to load because of an error related to recycling bitmaps on Android 4.2.2 device
- Logging into a Twitch account may not be possible if the WebView does not support TLS 1.2; also happened on the Android 4.2.2 device.

### Tested on
- Android 4.2.2
- Android 4.3
- Android 10

I didn't test while being logged into a Twitch account.

### Issues
- Closes #51
- May be related to #103
- `MediaSessionCompat` issue may be the cause of #64