### PR TITLE
Improve energy efficiency by applying Cache Energy Pattern

### DIFF
--- a/app/src/main/java/com/perflyst/twire/service/Service.java
+++ b/app/src/main/java/com/perflyst/twire/service/Service.java
@@ -29,6 +29,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.TrafficStats;
 import android.os.Build;
+import android.os.Process;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.TypedValue;
@@ -78,11 +79,7 @@ import java.util.Random;
 import java.util.Scanner;
 import java.util.TreeMap;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.*;
 
 /**
  * Created by Sebastian Rask on 12-02-2015.
@@ -714,6 +711,11 @@ public class Service {
         try {
             SSLContext sc = SSLContext.getInstance("TLS");
             sc.init(null, trustAllCerts, new SecureRandom());
+            SSLSessionContext sslSessionContext = sc.getServerSessionContext();
+            int sessionCacheSize = sslSessionContext.getSessionCacheSize();
+            if (sessionCacheSize > 0) {
+                sslSessionContext.setSessionCacheSize(0);
+            }
             HttpsURLConnection
                     .setDefaultSSLSocketFactory(sc.getSocketFactory());
         } catch (Exception e) {
@@ -993,7 +995,7 @@ public class Service {
     }
 
     public static double getDataReceived() {
-        return (double) TrafficStats.getUidRxBytes(android.os.Process
+        return (double) TrafficStats.getUidRxBytes(Process
                 .myUid()) / (1024 * 1024);
     }
 

--- a/app/src/main/java/com/perflyst/twire/utils/TLSSocketFactoryCompat.java
+++ b/app/src/main/java/com/perflyst/twire/utils/TLSSocketFactoryCompat.java
@@ -5,12 +5,9 @@ import java.net.InetAddress;
 import java.net.Socket;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
+import javax.net.ssl.*;
 
 
 /**
@@ -30,14 +27,23 @@ public class TLSSocketFactoryCompat extends SSLSocketFactory {
     public TLSSocketFactoryCompat() throws KeyManagementException, NoSuchAlgorithmException {
         SSLContext context = SSLContext.getInstance("TLS");
         context.init(null, null, null);
+        SSLSessionContext sslSessionContext = context.getServerSessionContext();
+        int sessionCacheSize = sslSessionContext.getSessionCacheSize();
+        if (sessionCacheSize > 0) {
+            sslSessionContext.setSessionCacheSize(0);
+        }
         internalSSLSocketFactory = context.getSocketFactory();
     }
-
 
     public TLSSocketFactoryCompat(final TrustManager[] tm)
             throws KeyManagementException, NoSuchAlgorithmException {
         SSLContext context = SSLContext.getInstance("TLS");
-        context.init(null, tm, new java.security.SecureRandom());
+        context.init(null, tm, new SecureRandom());
+        SSLSessionContext sslSessionContext = context.getServerSessionContext();
+        int sessionCacheSize = sslSessionContext.getSessionCacheSize();
+        if (sessionCacheSize > 0) {
+            sslSessionContext.setSessionCacheSize(0);
+        }
         internalSSLSocketFactory = context.getSocketFactory();
     }
 


### PR DESCRIPTION
This improves the energy efficiency of Twire by applying the Cache Energy Pattern for mobile applications.

The energy pattern was applied in Service.java and TLSSocketFactoryCompat.java . The general idea is to avoid performing unnecessary operations by increasing the size of the cache used. In particular, when a SSLContext is created, if the size of the cache has a limit, it's set to have no limit. 